### PR TITLE
Add flags option to toRegExp method

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,9 +227,11 @@ regenerate(0x1D306, 0x1F4A9).toString();
 // → '\\uD834\\uDF06|\\uD83D\\uDCA9'
 ```
 
-### `regenerate.prototype.toRegExp()`
+### `regenerate.prototype.toRegExp(flags = '')`
 
 Returns a regular expression that matches all the symbols mapped to the code points within the set.
+Optionally, you can pass [flags](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp#Parameters) 
+to be added to the regular expression.
 
 ```js
 var regex = regenerate(0x1D306, 0x1F4A9).toRegExp();
@@ -238,6 +240,9 @@ regex.test('𝌆');
 // → true
 regex.test('A');
 // → false
+
+// with flags
+var regex = regenerate(0x1D306, 0x1F4A9).toRegExp('g');
 ```
 
 **Note:** This probably shouldn’t be used. Regenerate is intended as a tool that is used as part of a build process, not at runtime.

--- a/regenerate.js
+++ b/regenerate.js
@@ -1071,8 +1071,8 @@
 			// Use `\0` instead of `\x00` where possible.
 			return result.replace(regexNull, '\\0$1');
 		},
-		'toRegExp': function() {
-			return RegExp(this.toString());
+		'toRegExp': function(flags) {
+			return RegExp(this.toString(), flags || '');
 		},
 		'valueOf': function() { // Note: `valueOf` is aliased as `toArray`.
 			return dataToArray(this.data);

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -197,6 +197,11 @@
 			/[\0-\xFF\u0201-\u0300]/,
 			'toRegExp'
 		);
+		deepEqual(
+			regenerate().addRange(0x0000, 0x0300).removeRange(0x0100, 0x0200).toRegExp('g'),
+			/[\0-\xFF\u0201-\u0300]/g,
+			'toRegExp flags'
+		);
 		raises(
 			function() {
 				regenerate(0x10, 0x1F).removeRange(0x1F, 0x1A).toArray();
@@ -685,7 +690,7 @@
 		);
 		deepEqual(
 			[regenerate.prototype.add.length, regenerate.prototype.remove.length, regenerate.prototype.addRange.length, regenerate.prototype.removeRange.length, regenerate.prototype.remove.length, regenerate.prototype.intersection.length, regenerate.prototype.contains.length, regenerate.prototype.clone.length, regenerate.prototype.toString.length, regenerate.prototype.toRegExp.length, regenerate.prototype.valueOf.length, regenerate.prototype.toArray.length],
-			[1, 1, 2, 2, 1, 1, 1, 0, 0, 0, 0, 0],
+			[1, 1, 2, 2, 1, 1, 1, 0, 0, 1, 0, 0],
 			'Regenerate methods are available on `regenerate.prototype`'
 		);
 		deepEqual(


### PR DESCRIPTION
I needed to add the global flag to the generated regexp.  Yeah, I could have done `new RegExp(set.toString(), 'g')` but this seems like something the helper method should support, so here it is. :smile:
