### PR TITLE
Fix Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: node_js
 node_js:
   - "0.10"


### PR DESCRIPTION
As a quick fix the distro is fixed as 'trusty', although it should be changed to a more recent Ubuntu version, but probably Rhino and/or Narwhal should be updated or changed -- Narwhal is marked as deprecated.